### PR TITLE
Add ARM support for kvaser-drivers-dkms

### DIFF
--- a/drivers/kvaser-drivers-dkms-mkdsc/debian/control
+++ b/drivers/kvaser-drivers-dkms-mkdsc/debian/control
@@ -8,6 +8,6 @@ Standards-Version: 4.1.2
 Homepage: https://www.kvaser.com/linux-drivers-and-sdk/
 
 Package: DEBIAN_PACKAGE-dkms
-Architecture: amd64
+Architecture: any
 Depends: dkms (>= 1.95), ${misc:Depends}
 Description: DEBIAN_PACKAGE in DKMS format.

--- a/drivers/kvaser-drivers-dkms-mkdsc/debian/rules
+++ b/drivers/kvaser-drivers-dkms-mkdsc/debian/rules
@@ -17,7 +17,7 @@ build: build-arch build-indep
 build-arch: build-stamp
 build-indep: build-stamp
 
-build-stamp: configure-stamp 
+build-stamp: configure-stamp
 	dh_testdir
 	$(MAKE)
 	touch $@
@@ -37,6 +37,17 @@ install: build
 	$(MAKE) DESTDIR=$(CURDIR)/debian/$(DEB_NAME)-dkms NAME=$(NAME) VERSION=$(VERSION) install
 
 binary-arch: build install
+	dh_testdir
+	dh_testroot
+	dh_link
+	dh_strip
+	dh_compress
+	dh_fixperms
+	dh_installdeb
+	dh_shlibdeps
+	dh_gencontrol
+	dh_md5sums
+	dh_builddeb
 
 binary-indep: build install
 	dh_testdir


### PR DESCRIPTION
Resolves #5 by adding the changes needed for successful ARM builds.

Launchpad ARM build:
https://launchpad.net/~astuff/+archive/ubuntu/kvaser-linux/+build/21080885